### PR TITLE
Tweak some fire settings

### DIFF
--- a/src/shaders/fire.wgsl
+++ b/src/shaders/fire.wgsl
@@ -101,15 +101,15 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var uv = fragCoord / iResolution.xy;
     
     // Movement vectors for distortion and fire
-    let distortionMovement = vec2f(0.01, -0.3);
-    let fireMovement = vec2f(0.01, -0.5);
+    let distortionMovement = vec2f(0.0, -0.3);
+    let fireMovement = vec2f(0.0, -0.5);
     
     // Parameters
     let normalStrength = 40.0;
     let distortionStrength = 0.1;
     
     // Calculate bump map (normal) for creating displacement
-    let uvT = vec2f(uv.x * 0.6, uv.y * 0.3) + distortionMovement * iTime;
+    let uvT = vec2f(uv.x * -0.6, uv.y * 0.3) + distortionMovement * iTime;
     let s = 1.0 / iResolution.x;
     
     let n0 = fbm(uvT, 1.0);
@@ -131,13 +131,13 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     );
     
     // Apply displacement and fire movement
-    let uvT2 = vec2f(uv.x * 0.6, uv.y * 0.5) + displacement + fireMovement * iTime;
+    let uvT2 = vec2f(uv.x, uv.y * 0.5) + displacement + fireMovement * iTime;
     
     // Get fire noise
-    let n = fbm(uvT2 * 8.0, 1.0);
+    let n = fbm(uvT2 * 11.0, 1.0);
     
     // Create vertical gradient - stronger at bottom
-    let gradientPower = 5.0 * pow(1.0 - uv.y, 2.0);
+    let gradientPower = 8.0 * pow(1.0 - uv.y, 3.5);
     
     // Final noise combined with gradient
     let finalNoise = n * gradientPower;


### PR DESCRIPTION
This pull request updates the fire shader in `src/shaders/fire.wgsl` to improve the fire's visual appearance by adjusting movement vectors, noise scaling, and the vertical gradient. The main focus is on making the fire effect more visually dynamic and realistic.

Shader visual improvements:

* Changed the `distortionMovement` and `fireMovement` vectors to have no horizontal movement, focusing the motion vertically for a more natural fire effect.
* Inverted the horizontal scaling of the UV coordinates for the bump map calculation, which affects the direction of distortion and adds variation to the fire's appearance.
* Removed horizontal scaling from the UV coordinates used for the fire's main noise pattern, resulting in a more uniform and less stretched look.
* Increased the frequency of the fire's noise pattern from 8.0 to 11.0, making the fire details finer and more turbulent.
* Adjusted the vertical gradient to be stronger and more concentrated at the bottom by increasing its power and exponent, enhancing the fire's glow and realism.

<img width="837" height="632" alt="NVIDIA_Overlay_CFYZ3DyaRF" src="https://github.com/user-attachments/assets/ee083070-a727-405f-87a1-49449375856e" />
