### PR TITLE
Add a rust build file windows bc thats what I'm building on

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,0 +1,19 @@
+name: Rust Build 🛠️
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --verbose

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -2,18 +2,18 @@ name: Rust Build 🛠️
 
 on:
   push:
-    branches: ["**"]
-  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-      - name: Checkout
+      - name: Checkout ✅
         uses: actions/checkout@v4
-      - name: Set up Rust
+      - name: Set up Rust 💻
         uses: dtolnay/rust-toolchain@stable
-      - name: Cache Cargo
+      - name: Cache Cargo 📦
         uses: Swatinem/rust-cache@v2
-      - name: Build
+      - name: Build 🔧
         run: cargo build --verbose

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,9 +1,12 @@
 name: Rust Build 🛠️
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for Rust projects. The workflow is triggered on all branch pushes and pull requests, and it runs the build on a Windows environment.

Continuous integration setup:

* Added a `.github/workflows/rust-build.yml` workflow that checks out the code, sets up the Rust toolchain, caches Cargo dependencies, and runs `cargo build` on Windows for all pushes and pull requests.